### PR TITLE
New versions of Node and Nginx containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   ##########################
 
   frontend:
-    image: node:7-alpine
+    image: node:8-alpine
     working_dir: /app
     labels:
       - 'traefik.backend=node'
@@ -34,7 +34,7 @@ services:
   # https://github.com/wodby/docker4drupal/blob/master/docker-compose.yml
 
   backend_php:
-    image: wodby/drupal-php:7.1-2.0.0
+    image: wodby/drupal-php:8-1.13
     # image: wodby/drupal-php:7.0-2.0.0
     environment:
       PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S backend_mailhog:1025


### PR DESCRIPTION
 - Updated node container to 8 version because it is current version 
 - Updated nginx container because of bug with drupal private files in old version